### PR TITLE
fix: 正文中参考文献引用的格式

### DIFF
--- a/shuthesis.cls
+++ b/shuthesis.cls
@@ -105,7 +105,7 @@
 \RequirePackage{tabu}
 \RequirePackage{booktabs}
 \RequirePackage{ulem}
-\RequirePackage[numbers,sort&compress]{natbib}
+\RequirePackage[numbers,sort&compress,super,square]{natbib}
 \patchcmd{\@chapter}{\addtocontents{lof}{\protect\addvspace{10\p@}}}{}{}{} % lof
 \patchcmd{\@chapter}{\addtocontents{lot}{\protect\addvspace{10\p@}}}{}{}{} % lot
 \RequirePackage{hyperref}


### PR DESCRIPTION
修复了正文中参考文献引用格式的问题。

根据学院提供的 office 模板，正文中的参考文献引用应该使用上标的方括号。 

修改前：
![image](https://user-images.githubusercontent.com/22931465/82120137-9b166680-97b6-11ea-8208-30393d2c0caf.png)

修改后：
![image](https://user-images.githubusercontent.com/22931465/82120214-1f68e980-97b7-11ea-8ead-203f747c01c8.png)
