### PR TITLE
Fix the format issue

### DIFF
--- a/data/abstract.tex
+++ b/data/abstract.tex
@@ -9,7 +9,7 @@
 
 \chapter*{摘\ 要}
 }
-\addcontentsline{toc}{chapter}{摘\ 要}
+%\addcontentsline{toc}{chapter}{摘\ 要}
 
 这里是中文摘要。
 
@@ -25,7 +25,7 @@
 
 \chapter*{ABSTRACT}
 }
-\addcontentsline{toc}{chapter}{ABSTRACT}
+%\addcontentsline{toc}{chapter}{ABSTRACT}
 
 Abstract in English.
 

--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -1,5 +1,5 @@
 % !Mode:: "TeX:UTF-8"
-\chapter{模板介绍}
+\mychapter{模板介绍}
 \label{cha:intro}
 
 \section{\shuthesis 模板（本模板的基模板）介绍}

--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -1,4 +1,5 @@
 % !Mode:: "TeX:UTF-8"
+% Please use \mychapter instead of \chapter
 \mychapter{模板介绍}
 \label{cha:intro}
 

--- a/data/chap02.tex
+++ b/data/chap02.tex
@@ -1,5 +1,5 @@
 % !Mode:: "TeX:UTF-8"
-\chapter{表格和插图}
+\mychapter{表格和插图}
 \label{chap:table} 
 
 \section{表格}

--- a/data/chap02.tex
+++ b/data/chap02.tex
@@ -1,4 +1,5 @@
 % !Mode:: "TeX:UTF-8"
+% Please use \mychapter instead of \chapter
 \mychapter{表格和插图}
 \label{chap:table} 
 

--- a/data/chap03.tex
+++ b/data/chap03.tex
@@ -1,4 +1,5 @@
 % !Mode:: "TeX:UTF-8"
+% Please use \mychapter instead of \chapter
 \mychapter{数学和定理环境}
 \label{cha:theorem}
 \section{数学宏包}

--- a/data/chap03.tex
+++ b/data/chap03.tex
@@ -1,5 +1,5 @@
 % !Mode:: "TeX:UTF-8"
-\chapter{数学和定理环境}
+\mychapter{数学和定理环境}
 \label{cha:theorem}
 \section{数学宏包}
 \LaTeX\ 最擅长处理的就是数学公式, \shuthesis\ 已经预加载了常用的数学宏包, 包括:

--- a/data/chap04.tex
+++ b/data/chap04.tex
@@ -1,4 +1,5 @@
 % !Mode:: "TeX:UTF-8"
+% Please use \mychapter instead of \chapter
 \mychapter{参考文献}
 \label{cha:bib}
 参考文献可以直接写在 \texttt{thebibliography} 环境里, 利用 \cs{bibitem} 罗列文献条

--- a/data/chap04.tex
+++ b/data/chap04.tex
@@ -1,5 +1,5 @@
 % !Mode:: "TeX:UTF-8"
-\chapter{参考文献}
+\mychapter{参考文献}
 \label{cha:bib}
 参考文献可以直接写在 \texttt{thebibliography} 环境里, 利用 \cs{bibitem} 罗列文献条
 目. 虽然费点功夫, 但是好控制, 各种格式可以自己随意改写.

--- a/main.tex
+++ b/main.tex
@@ -9,6 +9,7 @@
 \usepackage{pdfpages}
 \usepackage{shuthesis}
 \usepackage{times}
+\usepackage{zhnumber}
 \usepackage{gbt7714}
 \bibliographystyle{gbt7714-numerical}
 \citestyle{super}                   % 默认引用为角标格式，正文格式为\citestyle{numbers}
@@ -26,6 +27,14 @@
     \hypersetup{linkcolor=black}
     \tableofcontents
 }
+
+\setcounter{chapter}{0}
+\newcommand{\mychapter}[1]{
+  \stepcounter{chapter}
+  \chapter*{\thechapter #1}
+  \addcontentsline{toc}{chapter}{\zhnumber{\thechapter}、~~#1}
+}
+
 \include{data/abstract}
 
 \mainmatter
@@ -47,3 +56,4 @@
 \includepdf[pages={1}]{back-cover.pdf} 
 
 \end{document}
+

--- a/main.tex
+++ b/main.tex
@@ -28,6 +28,7 @@
     \tableofcontents
 }
 
+% Please use \mychapter instead of \chapter
 \setcounter{chapter}{0}
 \newcommand{\mychapter}[1]{
   \stepcounter{chapter}


### PR DESCRIPTION
https://github.com/shuosc/SHU-Bachelor-Thesis-OSC/issues/14#issue-1708449777

I fix the first and the second problem in this issue. But the third problem itself seems to be not true.

<img width="538" alt="image" src="https://github.com/shuosc/SHU-Bachelor-Thesis-OSC/assets/68705456/10798f6f-6974-490b-9c0c-141c33ca5a7b">

Here is my local texpad in the my current configuration.
![image](https://github.com/shuosc/SHU-Bachelor-Thesis-OSC/assets/68705456/b4bd268c-eb59-4eab-8ebb-1c9eb82a00a5)
![image](https://github.com/shuosc/SHU-Bachelor-Thesis-OSC/assets/68705456/0f01882d-71e7-4d9a-8fab-b53dd36fcd43)

Following is the word template:
<img width="766" alt="image" src="https://github.com/shuosc/SHU-Bachelor-Thesis-OSC/assets/68705456/7b1e4244-0800-4f4e-88d1-aa3864f6b5ac">
<img width="652" alt="image" src="https://github.com/shuosc/SHU-Bachelor-Thesis-OSC/assets/68705456/a190aeb0-b0e8-4430-bd3a-b9689273da0e">

The change I made is just rewrite a `\mychapter` function. So the user need to use `\mychapter` instead of `\chapter`.

![image](https://github.com/shuosc/SHU-Bachelor-Thesis-OSC/assets/68705456/31fb7930-2b54-4aa3-8601-ad072ed13a32)

If other contributors can redefine the `\chapter` without circular reference problems, maybe we can get back to use `\chapter`.