### PR TITLE
改变一级标题（chapter）格式

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -65,6 +65,9 @@
 % 起讫时间：
 \newcommand{\iThesisTime}{2024 年 12 月 30 日至 2025 年 5 月 23 日}
 
+\usepackage{titlesec}
+\ctexset {chapter={name={第,章},number={\chinese{chapter}}}}%去掉这两行则由“第一章 绪论”变为“1 绪论”
+
 \begin{document}
 \include{contents/cover}
 \include{contents/declaration}


### PR DESCRIPTION
为了满足最新格式要求（我是通信学院，不清楚全校情况），在 shuthesis.cls 或主文档中，添加了以下两行代码，使用 ctex 宏包和 titlesec 宏包对章节格式进行了修改：

\usepackage{titlesec}
\ctexset {chapter={name={第,章},number={\chinese{chapter}}}} 修改内容:

通过 \ctexset 配置，使章节标题显示为“第X章”格式，其中 X 是中文数字（例如“第一章”、“第二章”）。

如果注释这两行代码，章节标题将恢复为默认的阿拉伯数字格式（如“1 绪论”）。

灵感来源于https://www.zhihu.com/question/59347224