### PR TITLE
修改一级标题格式为中文

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -64,7 +64,7 @@
 \newcommand{\iSupervisorName}{余墨}
 % 起讫时间：
 \newcommand{\iThesisTime}{2024 年 12 月 30 日至 2025 年 5 月 23 日}
-
+\ctexset {chapter={name={第,章},number={\chinese{chapter}}}}%删掉这行则变为“1 绪论”
 \begin{document}
 \include{contents/cover}
 \include{contents/declaration}


### PR DESCRIPTION
加了一行\ctexset {chapter={name={第,章},number={\chinese{chapter}}}}
这将使章节标题从“1 绪论”变为“第一章 绪论”，以符合最新格式要求。
（注释了如果移除，章节标题会恢复为默认的阿拉伯数字形式。）