### PR TITLE
style: update reference format and abstract keyword format

### DIFF
--- a/contents/abstract.tex
+++ b/contents/abstract.tex
@@ -15,7 +15,7 @@
 点。
 
 \vspace{8mm}
-\textbf{关键词}: \TeX, \LaTeX, Template, Thesis
+\noindent \textbf{关键词}: \TeX； \LaTeX； Template； Thesis
 
 \newpage
 {
@@ -31,4 +31,4 @@ Abstract in English.
 
 \vspace{8mm}
 
-\textbf{Keywords}: \TeX, \LaTeX, Template, Thesis
+\noindent \textbf{Keywords}: \TeX; \LaTeX; Template; Thesis

--- a/shuthesis.cls
+++ b/shuthesis.cls
@@ -608,7 +608,8 @@
 \let\l@table\l@figure
 \renewenvironment{thebibliography}[1]{%
     \shu@chapter*{\bibname}%
-    \wuhao[1.5]
+    \xiaosi
+    \setlength{\baselineskip}{23pt}
     \list{\@biblabel{\@arabic\c@enumiv}}%
     {\renewcommand{\makelabel}[1]{##1\hfill}
         \settowidth\labelwidth{1.1cm}


### PR DESCRIPTION
## 1. PR Description

匹配2025年本科生毕业论文的格式，做了如下改动：
- 修改了参考文献的格式：字体小四、行距23磅（之前模板中设置的是五号字体）
- 修改中英文摘要中的关键词，顶格，关键词之间用分号

## 2. Related Issue and PR

## 3. Test

### Environment



| Software             | Version |
| -------------------- | ------- |
| OS / Docker Image    |    ubuntu 24.04     |
| Compiler             |    xelatex     |


## 4. Additional Context

修改后的效果

### 参考文献

原本是五号字体
![bib-wuhao](https://s2.loli.net/2025/05/21/aLIRXFcdV9KDkAb.png)

修改后
![bib-xiaosi](https://s2.loli.net/2025/05/21/VaHQiTFumrNfYjL.png)

### 摘要关键词

原本
![keywords-before](https://s2.loli.net/2025/05/21/XSxMfjdrkOv4ADp.png)

修改后
![keywords](https://s2.loli.net/2025/05/21/wQkbPIF7RVBCtnu.png)