### PR TITLE
[FEATURE] Adding a GitHub Actions CI workflow to automatically compile the LaTeX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,37 +22,45 @@ jobs:
       - name: Grant execution permission
         run: chmod +x scripts/build.sh
 
+      - name: Install Times New Roman fonts
+        run: |
+          apt-get update
+          echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
+          apt-get install -y ttf-mscorefonts-installer fontconfig
+          fc-cache -f -v
+
       - name: Compile LaTeX
         run: bash scripts/build.sh xebib
+
+      - name: Generate release info and rename PDF
+        id: release_info
+        run: |
+          DATE=$(date +'%Y%m%d')
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          PDF_NAME="SHUBachelorThesisExample_${DATE}_${SHORT_SHA}.pdf"
+          mv build/main.pdf "build/${PDF_NAME}"
+          echo "pdf_name=${PDF_NAME}" >> $GITHUB_OUTPUT
+          echo "tag_name=build-${DATE}-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          echo "release_name=Build ${DATE} (${SHORT_SHA})" >> $GITHUB_OUTPUT
 
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:
           name: SHU-Bachelor-Thesis-PDF
-          path: build/main.pdf
+          path: build/${{ steps.release_info.outputs.pdf_name }}
           if-no-files-found: error
-
-      - name: Generate release tag
-        if: github.event_name == 'push'
-        id: tag
-        run: |
-          DATE=$(date +'%Y.%m.%d')
-          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
-          TAG_NAME="build-${DATE}-${SHORT_SHA}"
-          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
-          echo "release_name=Build ${DATE} (${SHORT_SHA})" >> $GITHUB_OUTPUT
 
       - name: Create Release and Upload PDF
         if: github.event_name == 'push'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.tag_name }}
-          name: ${{ steps.tag.outputs.release_name }}
+          tag_name: ${{ steps.release_info.outputs.tag_name }}
+          name: ${{ steps.release_info.outputs.release_name }}
           body: |
             📄 **自动构建的论文 PDF**
 
             - **提交**: [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
             - **分支**: `${{ github.ref_name }}`
-            - **构建时间**: ${{ steps.tag.outputs.tag_name }}
-          files: build/main.pdf
+            - **构建时间**: ${{ steps.release_info.outputs.tag_name }}
+          files: build/${{ steps.release_info.outputs.pdf_name }}
           fail_on_unmatched_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,10 @@ name: Build Thesis PDF
 
 on:
   push:
-    branches: ["main", "master"]
     tags:
       - "v*"
   pull_request:
-    branches: ["main", "master"]
+    branches: ["master"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build Thesis PDF
 on:
   push:
     branches: ["main", "master"]
+    tags:
+      - "v*"
   pull_request:
     branches: ["main", "master"]
   workflow_dispatch:
@@ -35,29 +37,25 @@ jobs:
       - name: Compile LaTeX
         run: bash scripts/build.sh xebib
 
-      - name: Generate release info and rename PDF
-        id: release_info
+      - name: Generate PDF filename
+        id: pdf_info
         run: |
           DATE=$(date +'%Y%m%d')
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
           PDF_NAME="SHUBachelorThesisExample_${DATE}_${SHORT_SHA}.pdf"
           mv build/main.pdf "build/${PDF_NAME}"
           echo "pdf_name=${PDF_NAME}" >> $GITHUB_OUTPUT
-          echo "tag_name=build-${DATE}-${SHORT_SHA}" >> $GITHUB_OUTPUT
-          echo "release_name=PDF Review ${DATE} (${SHORT_SHA})" >> $GITHUB_OUTPUT
 
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:
           name: SHU-Bachelor-Thesis-PDF
-          path: build/${{ steps.release_info.outputs.pdf_name }}
+          path: build/${{ steps.pdf_info.outputs.pdf_name }}
           if-no-files-found: error
 
       - name: Create Release and Upload PDF
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.release_info.outputs.tag_name }}
-          name: ${{ steps.release_info.outputs.release_name }}
-          files: build/${{ steps.release_info.outputs.pdf_name }}
+          files: build/${{ steps.pdf_info.outputs.pdf_name }}
           fail_on_unmatched_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build Thesis PDF
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+    branches: ["main", "master"]
+  workflow_dispatch:
+
+jobs:
+  build_paper:
+    runs-on: ubuntu-latest
+    container:
+      image: texlive/texlive:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Grant execution permission
+        run: chmod +x scripts/build.sh
+
+      - name: Compile LaTeX
+        run: bash scripts/build.sh xebib
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SHU-Bachelor-Thesis-PDF
+          path: build/main.pdf
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           mv build/main.pdf "build/${PDF_NAME}"
           echo "pdf_name=${PDF_NAME}" >> $GITHUB_OUTPUT
           echo "tag_name=build-${DATE}-${SHORT_SHA}" >> $GITHUB_OUTPUT
-          echo "release_name=Build ${DATE} (${SHORT_SHA})" >> $GITHUB_OUTPUT
+          echo "release_name=PDF Review ${DATE} (${SHORT_SHA})" >> $GITHUB_OUTPUT
 
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     branches: ["main", "master"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build_paper:
     runs-on: ubuntu-latest
@@ -28,3 +31,28 @@ jobs:
           name: SHU-Bachelor-Thesis-PDF
           path: build/main.pdf
           if-no-files-found: error
+
+      - name: Generate release tag
+        if: github.event_name == 'push'
+        id: tag
+        run: |
+          DATE=$(date +'%Y.%m.%d')
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          TAG_NAME="build-${DATE}-${SHORT_SHA}"
+          echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+          echo "release_name=Build ${DATE} (${SHORT_SHA})" >> $GITHUB_OUTPUT
+
+      - name: Create Release and Upload PDF
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag_name }}
+          name: ${{ steps.tag.outputs.release_name }}
+          body: |
+            📄 **自动构建的论文 PDF**
+
+            - **提交**: [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+            - **分支**: `${{ github.ref_name }}`
+            - **构建时间**: ${{ steps.tag.outputs.tag_name }}
+          files: build/main.pdf
+          fail_on_unmatched_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,10 @@ jobs:
 
       - name: Install Times New Roman fonts
         run: |
+          # Enable contrib repository for mscorefonts
+          echo "deb http://deb.debian.org/debian testing contrib" >> /etc/apt/sources.list
           apt-get update
+          apt-get install -y cabextract
           echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
           apt-get install -y ttf-mscorefonts-installer fontconfig
           fc-cache -f -v

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,11 +56,5 @@ jobs:
         with:
           tag_name: ${{ steps.release_info.outputs.tag_name }}
           name: ${{ steps.release_info.outputs.release_name }}
-          body: |
-            📄 **自动构建的论文 PDF**
-
-            - **提交**: [`${{ github.sha }}`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
-            - **分支**: `${{ github.ref_name }}`
-            - **构建时间**: ${{ steps.release_info.outputs.tag_name }}
           files: build/${{ steps.release_info.outputs.pdf_name }}
           fail_on_unmatched_files: true

--- a/main.tex
+++ b/main.tex
@@ -31,22 +31,22 @@
 
 % 英文正文的字体：
 \setmainfont[
-    BoldFont=Times New Roman Bold,
-    ItalicFont=Times New Roman Italic,
-    BoldItalicFont=Times New Roman Bold Italic
-]{Times New Roman}
-% 英文的 sansfont 主要出现在 section 的标题中 (这里就把 Regular 直接设置为了 TimesNewRoman-Bold):
+    BoldFont=TeX Gyre Termes Bold,
+    ItalicFont=TeX Gyre Termes Italic,
+    BoldItalicFont=TeX Gyre Termes Bold Italic
+]{TeX Gyre Termes}
+% 英文的 sansfont 主要出现在 section 的标题中 (这里就把 Regular 直接设置为了 TeX Gyre Termes Bold):
 \setsansfont[
-    BoldFont=Times New Roman Bold,
-    ItalicFont=Times New Roman Bold Italic,
-    BoldItalicFont=Times New Roman Bold Italic
-]{Times New Roman Bold}
+    BoldFont=TeX Gyre Termes Bold,
+    ItalicFont=TeX Gyre Termes Bold Italic,
+    BoldItalicFont=TeX Gyre Termes Bold Italic
+]{TeX Gyre Termes Bold}
 % 英文的 monofont 主要出现在代码中 (\texttt), 可以根据自己的喜好调整：
 \setmonofont[
-    BoldFont=Times New Roman Bold,
-    ItalicFont=Times New Roman Italic,
-    BoldItalicFont=Times New Roman Bold Italic
-]{Times New Roman}
+    BoldFont=TeX Gyre Termes Bold,
+    ItalicFont=TeX Gyre Termes Italic,
+    BoldItalicFont=TeX Gyre Termes Bold Italic
+]{TeX Gyre Termes}
 
 
 % 下面是论文相关信息的填写：

--- a/main.tex
+++ b/main.tex
@@ -31,22 +31,22 @@
 
 % 英文正文的字体：
 \setmainfont[
-    BoldFont=TeX Gyre Termes Bold,
-    ItalicFont=TeX Gyre Termes Italic,
-    BoldItalicFont=TeX Gyre Termes Bold Italic
-]{TeX Gyre Termes}
-% 英文的 sansfont 主要出现在 section 的标题中 (这里就把 Regular 直接设置为了 TeX Gyre Termes Bold):
+    BoldFont=Times New Roman Bold,
+    ItalicFont=Times New Roman Italic,
+    BoldItalicFont=Times New Roman Bold Italic
+]{Times New Roman}
+% 英文的 sansfont 主要出现在 section 的标题中 (这里就把 Regular 直接设置为了 TimesNewRoman-Bold):
 \setsansfont[
-    BoldFont=TeX Gyre Termes Bold,
-    ItalicFont=TeX Gyre Termes Bold Italic,
-    BoldItalicFont=TeX Gyre Termes Bold Italic
-]{TeX Gyre Termes Bold}
+    BoldFont=Times New Roman Bold,
+    ItalicFont=Times New Roman Bold Italic,
+    BoldItalicFont=Times New Roman Bold Italic
+]{Times New Roman Bold}
 % 英文的 monofont 主要出现在代码中 (\texttt), 可以根据自己的喜好调整：
 \setmonofont[
-    BoldFont=TeX Gyre Termes Bold,
-    ItalicFont=TeX Gyre Termes Italic,
-    BoldItalicFont=TeX Gyre Termes Bold Italic
-]{TeX Gyre Termes}
+    BoldFont=Times New Roman Bold,
+    ItalicFont=Times New Roman Italic,
+    BoldItalicFont=Times New Roman Bold Italic
+]{Times New Roman}
 
 
 % 下面是论文相关信息的填写：


### PR DESCRIPTION
## 1. PR Description

添加 GitHub Actions CI/CD 工作流，实现：
- 自动编译 LaTeX 论文为 PDF
- 将 PDF 上传为 GitHub Artifacts
- 在推送到 main/master 分支时，自动创建 GitHub Release 并上传 PDF

这使得用户无需本地配置 LaTeX 环境即可获取最新编译的 PDF 文件。

## 2. Related Issue and PR

#58 

## 3. Test

### 3.1. Environment

| Software             | Version                    |
| -------------------- | -------------------------- |
| Compiler             | XeLaTeX (via build script) |
| Other Softwares      | GitHub Actions             |

### 3.2. Steps to Test

1. 推送任意更改到 `main` 或 `master` 分支
2. 检查 GitHub Actions 运行状态
3. 验证 PDF artifact 是否成功上传
4. 验证 GitHub Release 是否正确创建，包含 PDF 文件

### 3.3. Test Results

-  Workflow 在 push 和 pull_request 事件下触发正常
-  LaTeX 编译成功，生成 `build/main.pdf`
-  PDF 成功上传为 Artifact
-  Release 自动创建，标签格式为 `build-YYYY.MM.DD-<commit_sha>`

## 4. Additional Context

Release 标签格式：`build-{日期}-{commit短hash}`，例如 `build-2026.01.14-d39d026`

Release 包含：
- 编译好的 PDF 文件
- 提交链接
- 分支信息
- 构建时间